### PR TITLE
Update package description

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -15,6 +15,4 @@ Architecture: any
 Section: libdevel
 Depends: cmake
 Multi-Arch: same
-Description: Protobuf messages for ignitionics applications - Development files
- This library provides a set of google protobuf messages that are typically used
- in ignition applications. 
+Description: Ignition Robotics CMake Library - Development files


### PR DESCRIPTION
The package description for `ign-cmake2` seems to be the description for `ign-msgs`. I have fixed that here.

Signed-off-by: Ashton Larkin <ashton@openrobotics.org>