### PR TITLE
Move Breaks/Replaces to Jammy control file

### DIFF
--- a/bionic/debian/changelog
+++ b/bionic/debian/changelog
@@ -1,3 +1,9 @@
+ignition-cmake2 (2.11.0-2~bionic) bionic; urgency=medium
+
+  * ignition-cmake2 2.11.0-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Wed, 16 Mar 2022 12:28:47 +0100
+
 ignition-cmake2 (2.11.0-1~bionic) bionic; urgency=medium
 
   * ignition-cmake2 2.11.0-1 release

--- a/debian/buster/debian/changelog
+++ b/debian/buster/debian/changelog
@@ -1,3 +1,9 @@
+ignition-cmake2 (2.11.0-2~buster) buster; urgency=medium
+
+  * ignition-cmake2 2.11.0-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Wed, 16 Mar 2022 12:29:05 +0100
+
 ignition-cmake2 (2.11.0-1~buster) buster; urgency=medium
 
   * ignition-cmake2 2.11.0-1 release

--- a/debian/sid/debian/changelog
+++ b/debian/sid/debian/changelog
@@ -1,3 +1,9 @@
+ignition-cmake2 (2.11.0-2~sid) sid; urgency=medium
+
+  * ignition-cmake2 2.11.0-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Wed, 16 Mar 2022 12:29:06 +0100
+
 ignition-cmake2 (2.11.0-1~sid) sid; urgency=medium
 
   * ignition-cmake2 2.11.0-1 release

--- a/focal/debian/changelog
+++ b/focal/debian/changelog
@@ -1,3 +1,9 @@
+ignition-cmake2 (2.11.0-2~focal) focal; urgency=medium
+
+  * ignition-cmake2 2.11.0-2 release
+
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Wed, 16 Mar 2022 12:28:51 +0100
+
 ignition-cmake2 (2.11.0-1~focal) focal; urgency=medium
 
   * ignition-cmake2 2.11.0-1 release

--- a/jammy/debian/changelog
+++ b/jammy/debian/changelog
@@ -2,6 +2,12 @@ ignition-cmake2 (2.11.0-2~jammy) jammy; urgency=medium
 
   * ignition-cmake2 2.11.0-2 release
 
+ -- Jose Luis Rivero <jrivero@osrfoundation.org>  Wed, 16 Mar 2022 12:29:47 +0100
+
+ignition-cmake2 (2.11.0-2~jammy) jammy; urgency=medium
+
+  * ignition-cmake2 2.11.0-2 release
+
  -- Jose Luis Rivero <jrivero@osrfoundation.org>  Fri, 04 Mar 2022 18:25:14 +0100
 
 ignition-cmake2 (2.11.0-1~jammy) jammy; urgency=medium

--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -1,1 +1,26 @@
-../../ubuntu/debian/control
+Source: ignition-cmake2
+Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
+Section: science
+Priority: optional
+Build-Depends: cmake,
+               pkg-config,
+               debhelper (>= 11)
+Vcs-Browser: https://github.com/ignitionrobotics/ignition-cmake
+Vcs-Git: https://github.com/ignitionrobotics/ignition-cmake.git
+Standards-Version: 4.5.1
+Homepage: http://ignitionrobotics.org/
+
+Package: libignition-cmake2-dev
+Architecture: any
+Section: libdevel
+Depends: cmake, ${misc:Depends}
+Breaks: libignition-cmake-dev (<= 2.10.0-2)
+Replaces: libignition-cmake-dev (<= 2.10.0-2)
+Multi-Arch: same
+Description: Ignition Robotics CMake Library - Development files
+ CMake modules to be used by the Ignition projects.
+ .
+ This package is required to build ignition projects, as well as to link your
+ third party projects against them. It provides modules that are used to find
+ dependencies of ignition projects and generate cmake targets for consumers of
+ ignition projects to link against.

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -14,8 +14,6 @@ Package: libignition-cmake2-dev
 Architecture: any
 Section: libdevel
 Depends: cmake, ${misc:Depends}
-Breaks: libignition-cmake-dev (<= 2.10.0-2)
-Replaces: libignition-cmake-dev (<= 2.10.0-2)
 Multi-Arch: same
 Description: Ignition Robotics CMake Library - Development files
  CMake modules to be used by the Ignition projects.


### PR DESCRIPTION
Currently `ign-cmake2` has debians on Ubuntu 22.04 (Jammy) named `libignition-cmake-dev` (from upstream Ubuntu) and `libignition-cmake2-dev` (from packages.osrfoundation.org). A Breaks/Replaces statement was added in 7b75a4873d to acknowledge that conflict, but it applies to all platforms. A side-effect of this change is that `ign-cmake0` cannot be installed alongside `ign-cmake2` on 18.04 and 20.04, which I consider a regression. This would prevent gazebo9 from being installed alongside ignition-citadel for example. We have seen some CI failures in ign-math, which had a workaround merged in https://github.com/ignition-tooling/release-tools/pull/665, but failures are also cropping up in ign-common now as well.

This pull request fork the control file for Jammy to include the Breaks/Replaces statement from 7b75a4873d and revert the Breaks/Replaces statement from other platforms to allow side-by-side installs with old versions of ign-cmake0.