### PR TITLE
Add gz alias for Jammy

### DIFF
--- a/jammy/debian/control
+++ b/jammy/debian/control
@@ -5,10 +5,10 @@ Priority: optional
 Build-Depends: cmake,
                pkg-config,
                debhelper (>= 11)
-Vcs-Browser: https://github.com/ignitionrobotics/ignition-cmake
-Vcs-Git: https://github.com/ignitionrobotics/ignition-cmake.git
+Vcs-Browser: https://github.com/gazebosim/gz-cmake
+Vcs-Git: https://github.com/gazebosim/gz-cmake.git
 Standards-Version: 4.5.1
-Homepage: http://ignitionrobotics.org/
+Homepage: http://gazebosim.org/
 
 Package: libignition-cmake2-dev
 Architecture: any
@@ -21,7 +21,15 @@ Multi-Arch: same
 Description: Gazebo CMake Library - Development files
  CMake modules to be used by the Gazebo projects.
  .
- This package is required to build ignition projects, as well as to link your
+ This package is required to build Gazebo projects, as well as to link your
  third party projects against them. It provides modules that are used to find
- dependencies of ignition projects and generate cmake targets for consumers of
- ignition projects to link against.
+ dependencies of Gazebo projects and generate cmake targets for consumers of
+ Gazebo projects to link against.
+
+Package: libgz-cmake2-dev
+Depends: libignition-cmake2-dev, ${misc:Depends}
+Architecture: all
+Priority: optional
+Section: oldlibs
+Description: transitional package
+ It's recommended to use the gz packages going forward.


### PR DESCRIPTION
* Follow up to https://github.com/gazebo-release/gz-cmake2-release/pull/5
* Part of https://github.com/gazebo-tooling/release-tools/issues/788

I didn't realize the Jammy file was separate